### PR TITLE
Minor edits from a quick read

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -7,7 +7,7 @@
   year      = {2018},
   month     = {11},
   volume    = {14},
-  pages     = {1-21},
+  pages     = {1--21},
   number    = {11}
 }
 
@@ -18,7 +18,7 @@
   pages     = {genetics.303253.2020},
   publisher = {Genetics Society of America},
   title     = {Efficiently Summarizing Relationships in Large Samples: A General Duality Between Statistics of Genealogies and Genomes},
-  year      = 2020
+  year      = {2020}
 }
 
 @article{wong2024general,
@@ -60,9 +60,8 @@
   author  = {Nielsen, Rasmus and Vaughn, Andrew H. and Deng, Yun},
   journal = {Nature Reviews Genetics},
   year    = {2024},
-  volume  = {},
-  number  = {},
-  pages   = {},
+  volume  = {26},
+  pages   = {47--58},
   doi     = {10.1038/s41576-024-00772-4},
   url     = {https://doi.org/10.1038/s41576-024-00772-4}
 }
@@ -83,8 +82,8 @@
   author  = {Luke Anderson-Trocm{\'e} and Dominic Nelson and Shadi Zabad and Alex Diaz-Papkovich and Ivan Kryukov and Nikolas Baya and Mathilde Touvier and Ben Jeffery and Christian Dina and H{\'e}l{\`e}ne V{\'e}zina and Jerome Kelleher and Simon Gravel},
   journal = {Science},
   number  = {6647},
-  pages   = {849-855},
-  title   = {On the genes, genealogies, and geographies of Quebec},
+  pages   = {849--855},
+  title   = {On the genes, genealogies, and geographies of {Quebec}},
   volume  = {380},
   year    = {2023}
 }
@@ -102,7 +101,7 @@
   author  = {Wohns, Anthony Wilder and Wong, Yan and Jeffery, Ben and Akbari, Ali and Mallick, Swapan and Pinhasi, Ron and Patterson, Nick and Reich, David and Kelleher, Jerome and McVean, Gil},
   journal = {Science},
   pages   = {eabi8264},
-  title   = {A unified genealogy of modern and ancient genomes.},
+  title   = {A unified genealogy of modern and ancient genomes},
   volume  = {375},
   year    = {2022}
 }
@@ -118,11 +117,20 @@
   journal = {bioRxiv}
 }
 
-@article{Haller2025,
+@article{haller2025simHumanity,
   author  = {Haller, Benjamin C. and Nelson, Chase W. and Rodrigues, Murillo F. and Messer, Philipp W.},
   title   = {{SimHumanity: Using SLiM} 5.0 to run whole-genome simulations of human evolution},
   journal = {Human Population Genetics and Genomics},
   year    = {2025},
   doi     = {10.47248/hpgg2505040006},
   url     = {http://dx.doi.org/10.47248/hpgg2505040006}
+}
+
+@article{pope2026tracing,
+  author  = {Pope, Nathaniel S. and Tallman, Sam and Jeffery, Ben and Robertson, Duncan and Wong, Yan and Karthikeyan, Savita and Ralph, Peter L. and Kelleher, Jerome},
+  title   = {Tracing the evolutionary histories of ultra-rare variants using variational dating of large ancestral recombination graphs},
+  journal = {bioRxiv},
+  year    = {2026},
+  doi     = {10.64898/2026.01.07.698223},
+  url     = {http://dx.doi.org/10.64898/2026.01.07.698223}
 }

--- a/paper.tex
+++ b/paper.tex
@@ -26,7 +26,8 @@ constrained by the lack of scalable inference methods, standard
 interchange formats, and software infrastructure. Recent breakthroughs in
 simulation and inference have substantially changed this landscape,
 leading to renewed interest in ARG-based analyses across population and statistical
-genetics\cite{brandt2024promise,lewanski2024era,nielsen2024inference}.
+%genetics\cite{brandt2024promise,lewanski2024era,nielsen2024inference}.
+genetics\cite{lewanski2024era}.
 The tskit library has played a key enabling role in this shift
 and has become foundational infrastructure for working with ARGs at scale.
 This paper marks the release of tskit 1.0, which formalises long-term stability
@@ -72,7 +73,7 @@ method evaluation. Simulation capabilities have continued to expand,
 culminating in whole-genome ARG simulations for nearly 1.5 million individuals
 based on a large human pedigree\cite{andersontrocme2023genes}
 and recently the complete human genome,
-including sex chromosomes and mitochondrial DNA\cite{Haller2025}.
+including sex chromosomes and mitochondrial DNA\cite{haller2025simHumanity}.
 A growing ecosystem of simulation tools now builds directly on tskit
 (Table 1).
 
@@ -224,21 +225,24 @@ tspop & Python & pypi & 2023 & 12 \\
 \end{scriptsize}
 \end{table}
 
-% Citations:
+% There is a hard limit of 10 references for this type of article!
+% Citations (sorted alphabetically here for ease of editing):
 
-% - wong2024general
-% - brandt2024promise
-% - lewanski2024era
-% - nielsen2024inference
-% - kelleher2016efficient
-% - kelleher2019inferring
-% - ralph2020efficiently
-% - andersontrocme2023genes
-% - zhan2025pandemic
+% 1 - andersontrocme2023genes
+% X - brandt2024promise The Promise of Inferring the Past Using the Ancestral Recombination Graph
+% 2 - haller2025simHumanity
+% 3 - lewanski2024era The era of the ARG: An introduction to ancestral recombination graphs and their significance in empirical evolutionary genomics
+% X - nielsen2024inference Inference and applications of ancestral recombination graphs
+% 4 - kelleher2016efficient
+% 5 - kelleher2018efficient
+% 6 - kelleher2019inferring
+% 7 - ralph2020efficiently
+% 8 - wohns2022unified or pope2026tracing TODO: pick one of these two
+% 9 - wong2024general
+% 10 - zhan2025pandemic
 
 \section*{Acknowledgments}
 
 \bibliography{paper}
-
 
 \end{document}


### PR DESCRIPTION
Minor edits from a quick read - diffs are large due to formatting or stripping trailing whitespace